### PR TITLE
ADD: security_group_referencing_support in resource aws_ec2_transit_g…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.7.0 (October 9, 2024)
+
+FEATURE:
+  * Supports Transit Gateway Security Group Referencing
+
 ## 1.6.0 (August 9, 2024)
 
 FEATURE:

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ No modules.
 | <a name="input_create_peering_attachment_accepter"></a> [create\_peering\_attachment\_accepter](#input\_create\_peering\_attachment\_accepter) | Determines whether to create a tgw peering attachment or not. | `bool` | `false` | no |
 | <a name="input_dns_support"></a> [dns\_support](#input\_dns\_support) | (Optional) Whether DNS support is `enabled`. Valid values: `disable`, `enable`. Default value: `enable`. | `string` | `"enable"` | no |
 | <a name="input_ipv6_support"></a> [ipv6\_support](#input\_ipv6\_support) | (Optional) Whether IPv6 support is `enabled`. Valid values: `disable`, `enable`. Default value: `disable`. | `string` | `"disable"` | no |
+| <a name="input_security_group_referencing_support"></a> [security\_group\_referencing\_support](#input\_security\_group\_referencing\_support) | (Optional) Whether Security Group Referencing support is `enabled`. Valid values: `disable`, `enable`. Default value: `disable`. | `string` | `"disable"` | no |
 | <a name="input_local_gateway_routes"></a> [local\_gateway\_routes](#input\_local\_gateway\_routes) | Map of objects that define the local gateway routes to be created | `any` | `{}` | no |
 | <a name="input_nat_gateway_routes"></a> [nat\_gateway\_routes](#input\_nat\_gateway\_routes) | Map of objects that define the nat gateway routes to be created | `any` | `{}` | no |
 | <a name="input_network_interface_routes"></a> [network\_interface\_routes](#input\_network\_interface\_routes) | Map of objects that define the network interface routes to be created | `any` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -69,12 +69,14 @@ locals {
 resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
   for_each = { for k, v in var.transit_gateway_attachments : k => v if var.create_attachment }
 
-  vpc_id                 = each.value.vpc_id
-  subnet_ids             = each.value.subnet_ids
-  transit_gateway_id     = each.value.transit_gateway_id
-  appliance_mode_support = var.appliance_mode_support
-  dns_support            = var.dns_support
-  ipv6_support           = var.ipv6_support
+  vpc_id                             = each.value.vpc_id
+  subnet_ids                         = each.value.subnet_ids
+  transit_gateway_id                 = each.value.transit_gateway_id
+  appliance_mode_support             = var.appliance_mode_support
+  dns_support                        = var.dns_support
+  ipv6_support                       = var.ipv6_support
+  security_group_referencing_support = var.security_group_referencing_support
+
 
   transit_gateway_default_route_table_association = var.transit_gateway_default_route_table_association
   transit_gateway_default_route_table_propagation = var.transit_gateway_default_route_table_propagation

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,12 @@ variable "ipv6_support" {
   default     = "disable"
 }
 
+variable "security_group_referencing_support" {
+  description = "(Optional) Whether Security Group Referencing support is `enabled`. Valid values: `disable`, `enable`. Default value: `disable`."
+  type        = string
+  default     = "disable"
+}
+
 variable "transit_gateway_default_route_table_association" {
   description = "(Optional) Boolean whether the VPC Attachment should be associated with the EC2 Transit Gateway association default route table. This cannot be configured or perform drift detection with Resource Access Manager shared EC2 Transit Gateways. Default value: `true`."
   type        = bool


### PR DESCRIPTION
Feature: add security_group_referencing_support to resource aws_ec2_transit_gateway_vpc_attachment for aws 5.69.0 version

## Description
<!--- Describe your changes in detail -->
Added functional to add security_group_referencing_support in aws_ec2_transit_gateway_vpc_attachment

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Now it is possible to usesecurity_group_referencing_support
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
