### PR TITLE
Update NAT Gateway Route to reference NAT Gateway IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.7.1 (March 7, 2025)
 
-FIX:
+BUG:
   * Update the NAT Gateway route to use the correct NAT Gateway ID.
 
 ## 1.7.0 (October 9, 2024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.7.1 (March 7, 2025)
+
+FIX:
+  * Update the NAT Gateway route to use the correct NAT Gateway ID.
+
 ## 1.7.0 (October 9, 2024)
 
 FEATURE:

--- a/main.tf
+++ b/main.tf
@@ -134,7 +134,7 @@ resource "aws_route" "this_nat_gateway_route" {
 
   route_table_id            = each.value.route_table_id
   destination_cidr_block    = each.value.destination_cidr_block
-  vpc_peering_connection_id = each.value.vpc_peering_connection_id
+  nat_gateway_id            = each.value.nat_gateway_id
 }
 
 resource "aws_route" "this_local_gateway_route" {


### PR DESCRIPTION
Updates:
- Swap out `vpc_peering_connectdion_id` assignment for `nat_gateway_id` to match the route's context.

## Description
<!--- Describe your changes in detail -->
When defining NAT gateway routes, e.g. (Terragrunt extract):
```
inputs = {
  ...
  nat_gateway_routes = {
    "my_awesome_route" = {
      route_table_ids         = dependency.vpc.outputs.route_table_ids
      destination_cidr_blocks = [ "0.0.0.0/0" ]
      nat_gateway_id          = dependency.vpc.outputs.natgw_ids[0]
    },
  }
  ...
}
```

Applying v1.7.0 results in the following error:
```
# terragrunt --terragrunt-provider-cache apply
INFO[0000] Terragrunt Cache server is listening on 127.0.0.1:40399 
INFO[0000] Start Terragrunt Cache server                
INFO[0066] Downloading Terraform configurations from tfr:///terraform-aws-modules/vpc/aws?version=5.13.0 into /workspace/infrastructure/terragrunt/aws/network/SOME_COMPANY/SOME_DIVISION/europe/development/platform/eu-west-2/vpc/.terragrunt-cache/eY82BiAtdaxfVfRyXGe6LbiKZFA/ThyYwttwki6d6AS3aD5OwoyqIWA  prefix=[/workspace/infrastructure/terragrunt/aws/network/SOME_COMPANY/SOME_DIVISION/europe/development/platform/eu-west-2/vpc] 
INFO[0072] Downloading Terraform configurations from tfr:///terraform-aws-modules/vpc/aws?version=5.13.0 into /workspace/infrastructure/terragrunt/aws/network/SOME_COMPANY/SOME_DIVISION/europe/development/hub/eu-west-2/vpc/.terragrunt-cache/G2g_7dg90pj9DDaXo_R-fj6oGNU/ThyYwttwki6d6AS3aD5OwoyqIWA  prefix=[/workspace/infrastructure/terragrunt/aws/network/SOME_COMPANY/SOME_DIVISION/europe/development/hub/eu-west-2/vpc] 
INFO[0124] Downloading Terraform configurations from tfr:///terraform-aws-modules/transit-gateway/aws?version=2.13.0 into /workspace/infrastructure/terragrunt/aws/network/SOME_COMPANY/SOME_DIVISION/europe/development/hub/eu-west-2/vpc/tgw/.terragrunt-cache/JEnBxw1reuS4mdDC9ehbrRTYxb4/KRsz1FK4E3qMv57_d93AvMeQ4pA  prefix=[/workspace/infrastructure/terragrunt/aws/network/SOME_COMPANY/SOME_DIVISION/europe/development/hub/eu-west-2/vpc/tgw] 
INFO[0179] Downloading Terraform configurations from tfr:///adamwshero/transit-gateway-attachment/aws?version=1.7.0 into /workspace/infrastructure/terragrunt/aws/network/SOME_COMPANY/SOME_DIVISION/europe/development/platform/eu-west-2/vpc/tgw_attachment/.terragrunt-cache/hqd7SVXJuQTdRkqbJ1xwxSPlvDs/NcCFGaB3GW5cqVoDvyZbktWpgwE 
INFO[0181] Caching terraform providers for /workspace/infrastructure/terragrunt/aws/network/SOME_COMPANY/SOME_DIVISION/europe/development/platform/eu-west-2/vpc/tgw_attachment/.terragrunt-cache/hqd7SVXJuQTdRkqbJ1xwxSPlvDs/NcCFGaB3GW5cqVoDvyZbktWpgwE 

Initializing the backend...

Initializing provider plugins...
- Reusing previous version of hashicorp/aws from the dependency lock file
- Reusing previous version of hashicorp/random from the dependency lock file
- Installing hashicorp/aws v5.90.0...
- Installed hashicorp/aws v5.90.0 (unauthenticated)
- Installing hashicorp/random v3.7.1...
- Installed hashicorp/random v3.7.1 (unauthenticated)

OpenTofu has been successfully initialized!

...

Planning failed. OpenTofu encountered an error while generating this plan.

╷
│ Error: Unsupported attribute
│ 
│   on main.tf line 137, in resource "aws_route" "this_nat_gateway_route":
│  137:   vpc_peering_connection_id = each.value.vpc_peering_connection_id
│     ├────────────────
│     │ each.value is object with 3 attributes
│ 
│ This object does not have an attribute named "vpc_peering_connection_id".
╵
ERRO[0240] tofu invocation failed in /workspace/infrastructure/terragrunt/aws/network/SOME_COMPANY/SOME_DIVISION/europe/development/platform/eu-west-2/vpc/tgw_attachment/.terragrunt-cache/hqd7SVXJuQTdRkqbJ1xwxSPlvDs/NcCFGaB3GW5cqVoDvyZbktWpgwE  error=[/workspace/infrastructure/terragrunt/aws/network/SOME_COMPANY/SOME_DIVISION/europe/development/platform/eu-west-2/vpc/tgw_attachment/.terragrunt-cache/hqd7SVXJuQTdRkqbJ1xwxSPlvDs/NcCFGaB3GW5cqVoDvyZbktWpgwE] exit status 1 prefix=[/workspace/infrastructure/terragrunt/aws/network/SOME_COMPANY/SOME_DIVISION/europe/development/platform/eu-west-2/vpc/tgw_attachment] 

...
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Required as NAT gateway routes should be supported.
- This resolves the apply-time error above.
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
- No, NAT gateway routes would never have applied. They should now.
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request:
  ```
  # pre-commit run -a                          
  An error has occurred: InvalidConfigError: 
  =====> .pre-commit-config.yaml is not a file
  Check the log at /root/.cache/pre-commit/pre-commit.log
  ```
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
